### PR TITLE
New script for updating varchar length

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
 **This Repo contains code and procedures to select optimal data structure while migrating from Greenplum to Amazon Redshift**
 
-#Data Structure profiling is essential to avoid numeric overflow or character values that are too long. This repositroy consists of list of SQL's queries **you can execute on Greenplum Database to come up with right sizing data strcutures 
+* Data Structure profiling is essential to avoid numeric overflow or character values that are too long. This repositroy consists of list of SQL's queries **you can execute on Greenplum Database to come up with right sizing data strcutures 
 
-#The profiling result is based on the dataset for a particular instance of time. Always execute SQL;s in your latest Greenplum production environment to capture the right results . You need to determine the best time window for the same to avoid a performance bottleneck in production. Running in any other environment that gets the Greenplum production data synced with lag, even for a couple of days or weeks, works for most implementations as long as there is no drastic change in the data structures.
+* The profiling result is based on the dataset for a particular instance of time. Always execute SQL;s in your latest Greenplum production environment to capture the right results . You need to determine the best time window for the same to avoid a performance bottleneck in production. Running in any other environment that gets the Greenplum production data synced with lag, even for a couple of days or weeks, works for most implementations as long as there is no drastic change in the data structures.
 
 
-**Sample data profiling process**
+## Data profiling
 The following example data profiling procedure uses the sample queries defined in the prior sections.
 
 1.	Create tables to store your profiling result based on the type of profiling query you plan to use.
@@ -23,7 +23,9 @@ The following example data profiling procedure uses the sample queries defined i
     ii.	If the column length is not defined, set the VARCHAR column length as 120% of the higher of max_datalength and max_octetlength.
     iii.	During migration, if any other columns fail with the message that the value is too long for the character type, you need to handle these on a      case-by-case basis. The chances of encountering this are minimal and depend on the quality of the profiled data and the gap between the profiling and    actual migration date.
 
+## Enhancing Greenplum DDL
 
+add_varchar_lengths.sh: Change unbounded varchar and text columns in a given schema to have length constraints in Greenplum. This helps in the migration to Redshift with AWS Schema Conversion Tool (SCT) and avoids treating these columns as LOBs.
 
 ## Security
 

--- a/add_varchar_lengths.sh
+++ b/add_varchar_lengths.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -e
+
+table_schema="$1"
+if [ "${table_schema}" == "" ]; then
+	echo "ERROR: You must provide the name of the schema you wish to fix the data type lengths."
+	exit 1
+fi
+schema_check=$(psql -t -A -c "SELECT count(*) FROM pg_namespace WHERE nspname = '${table_schema}' and nspname not like 'pg_%' and nspname <> 'gp_toolkit'")
+if [ "${schema_check}" -eq "0" ]; then
+	echo "ERROR: Schema \"${table_schema}\" not found!"
+	exit 1
+fi
+drop_indexes()
+{
+	#called from alter_tables()
+	table_name_check="$1"
+	column_name_check="$2"
+	for i in $(psql -t -A -c "SELECT i.relname AS index_name, ix.indisunique FROM pg_class t JOIN pg_namespace ts ON t.relnamespace = ts.oid JOIN (select indisunique, indexrelid, indrelid, unnest(indkey) AS indkey FROM pg_index) ix ON t.oid = ix.indrelid JOIN pg_attribute a on t.oid = a.attrelid and a.attnum = ix.indkey JOIN pg_class i on i.oid = ix.indexrelid JOIN pg_namespace i_s on i.relnamespace = i_s.oid WHERE t.relkind = 'r' AND ts.nspname = '${table_schema}' AND t.relname = '${table_name_check}' AND a.attname = '${column_name_check}'"); do
+		index_name=$(echo $i | awk -F '|' '{print $1}')
+		unique_ind=$(echo $i | awk -F '|' '{print $2}')
+		if [ "$unique_ind" == "t" ]; then
+			psql -e -c "ALTER TABLE \"${table_schema}\".\"${table_name_check}\" DROP CONSTRAINT \"${index_name}\""
+		else
+			psql -e -c "DROP INDEX IF EXISTS \"${table_schema}\".\"${index_name}\""
+		fi
+	done
+}
+alter_tables()
+{
+	for table_name in $(psql -t -A -c "SELECT c.relname FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid JOIN pg_attribute a ON c.oid = a.attrelid JOIN pg_type t ON a.atttypid = t.oid WHERE c.relkind = 'r' AND c.oid NOT IN (SELECT c1.oid FROM pg_class c1 JOIN pg_inherits i ON c1.oid = i.inhrelid WHERE c1.relkind = 'r') AND n.nspname = '${table_schema}' AND t.typname IN ('varchar', 'text') AND a.atttypmod = -1 GROUP BY c.relname"); do
+		test_for_data=$(psql -t -A -c "SELECT 1 FROM ${table_schema}.${table_name} limit 1" | wc -l)
+		if [ "$test_for_data" -gt "0" ]; then
+			column_count="0"
+			columns=()
+			for column_name in $(psql -t -A -c "SELECT a.attname FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid JOIN pg_attribute a ON c.oid = a.attrelid JOIN pg_type t ON a.atttypid = t.oid WHERE c.relkind = 'r' AND c.relname = '${table_name}' AND c.oid NOT IN (SELECT c1.oid FROM pg_class c1 JOIN pg_inherits i ON c1.oid = i.inhrelid WHERE c1.relkind = 'r') AND n.nspname = '${table_schema}' AND t.typname in ('varchar', 'text') AND a.atttypmod = -1 order by a.attnum"); do
+
+				drop_indexes "${table_name}" "${column_name}"
+				column_count=$((column_count+1))
+				columns+=(${column_name})
+				if [ "$column_count" -eq "1" ]; then
+					sql_text="SELECT max(coalesce(length(\"${column_name}\"),0))"
+				else
+					sql_text+=", max(coalesce(length(\"${column_name}\"),0))"
+				fi
+			done
+			if [ "$column_count" -gt "0" ]; then
+				sql_text+=" FROM ${table_schema}.${table_name}"
+				i=0
+				SAVEIFS=$IFS
+				IFS="|"
+				for column_max in $(psql -t -A -c "${sql_text}"); do
+					column_name=${columns[$i]}
+					if [ "${column_max}" -eq "0" ]; then
+						alter_sql="ALTER TABLE \"${table_schema}\".\"${table_name}\" ALTER COLUMN \"${column_name}\" TYPE varchar(10)"
+					elif [ "${column_max}" -lt "50" ]; then
+						alter_sql="ALTER TABLE \"${table_schema}\".\"${table_name}\" ALTER COLUMN \"${column_name}\" TYPE varchar(50)"
+					elif [[ "${column_max}" -ge "50" && "${column_max}" -lt "100" ]]; then
+						alter_sql="ALTER TABLE \"${table_schema}\".\"${table_name}\" ALTER COLUMN \"${column_name}\" TYPE varchar(100)"
+					elif [[ "${column_max}" -ge "100" && "${column_max}" -lt "500" ]]; then
+						alter_sql="ALTER TABLE \"${table_schema}\".\"${table_name}\" ALTER COLUMN \"${column_name}\" TYPE varchar(500)"
+					elif [[ "${column_max}" -ge "500" && "${column_max}" -lt "1000" ]]; then
+						alter_sql="ALTER TABLE \"${table_schema}\".\"${table_name}\" ALTER COLUMN \"${column_name}\" TYPE varchar(1000)"
+					elif [ "${column_max}" -ge "1000" ]; then
+						alter_sql="ALTER TABLE \"${table_schema}\".\"${table_name}\" ALTER COLUMN \"${column_name}\" TYPE varchar(30000)"
+					fi
+					echo "${alter_sql}"
+					psql -c "${alter_sql}"
+					i=$((i+1))
+				done
+				IFS=$SAVEIFS
+			fi
+		else
+			for column_name in $(psql -t -A -c "SELECT a.attname FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid JOIN pg_attribute a ON c.oid = a.attrelid JOIN pg_type t ON a.atttypid = t.oid WHERE c.relkind = 'r' AND c.relname = '${table_name}' AND c.oid NOT IN (SELECT c1.oid FROM pg_class c1 JOIN pg_inherits i ON c1.oid = i.inhrelid WHERE c1.relkind = 'r') AND n.nspname = '${table_schema}' AND t.typname in ('varchar', 'text') AND a.atttypmod = -1"); do
+				drop_indexes "${table_name}" "${column_name}"
+				alter_sql="ALTER TABLE \"${table_schema}\".\"${table_name}\" ALTER COLUMN \"${column_name}\" TYPE varchar(500)"
+				psql -e -c "${alter_sql}"
+			done
+		fi
+	done
+}
+
+alter_tables


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
New script helps with the migration of Greenplum to Redshift by finding and updating columns for a given schema that are either text or unbounded varchar to have a length added. When using SCT to migrate Greenplum to Redshift, SCT will treat these columns as a CLOB which isn't useful for customers when most times, the data length is much shorter. Redshift allows up to 64K characters in a varchar field and best practice is to keep this as small as possible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
